### PR TITLE
When build host is Linux change owner of output/, build/ and

### DIFF
--- a/scripts/build-openocd.sh
+++ b/scripts/build-openocd.sh
@@ -667,6 +667,18 @@ do
       helper_script="$2"
       shift 2
       ;;
+    --group-id)
+      group_id="$2"
+      shift 2
+      ;;
+    --user-id)
+      user_id="$2"
+      shift 2
+      ;;
+    --host-uname)
+      host_uname="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option $1, exit."
       exit 1

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -819,6 +819,18 @@ do
       helper_script="$2"
       shift 2
       ;;
+    --group-id)
+      group_id="$2"
+      shift 2
+      ;;
+    --user-id)
+      user_id="$2"
+      shift 2
+      ;;
+    --host-uname)
+      host_uname="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option $1, exit."
       exit 1


### PR DESCRIPTION
install/ directories from root to the build host user and group
running the build script. (Build host OSX produces the expected
owner/group for the produced directories.)
    modified:   scripts/build-helper.sh
    modified:   scripts/build-openocd.sh
