### PR TITLE
For Linux openocd executables, set runpath instead of rpath to $ORIGIN

### DIFF
--- a/scripts/build-helper.sh
+++ b/scripts/build-helper.sh
@@ -288,10 +288,10 @@ do
         echo "Needed:"
         sort -u /tmp/mylibs
 
-        rpl=$(readelf -d "${distribution_executable_name}" | egrep -i 'rpath' | sed -e 's/.*\[\(.*\)\]/\1/')
+        rpl=$(readelf -d "${distribution_executable_name}" | egrep -i 'runpath' | sed -e 's/.*\[\(.*\)\]/\1/')
         if [ "$rpl" != '$ORIGIN' ]
         then
-          echo "Wrong rpath $rpl"
+          echo "Wrong runpath $rpl"
           exit 1
         fi
         popd
@@ -591,9 +591,9 @@ do_copy_user_so() {
   if [ ! -z "${ILIB}" ]
   then
     echo "Found user ${ILIB}"
-    set +e
+
+    # Add "runpath" in library with value $ORIGIN.
     patchelf --set-rpath '$ORIGIN' "${ILIB}"
-    set -e
 
     ILIB_BASE="$(basename ${ILIB})"
     /usr/bin/install -v -c -m 644 "${ILIB}" "${install_folder}/${APP_LC_NAME}/bin"
@@ -606,9 +606,9 @@ do_copy_user_so() {
     if [ ! -z "${ILIB}" ]
     then
       echo "Found user 2 ${ILIB}"
-      set +e
+
+      # Add "runpath" in library with value $ORIGIN.
       patchelf --set-rpath '$ORIGIN' "${ILIB}"
-      set -e
 
       ILIB_BASE="$(basename ${ILIB})"
       /usr/bin/install -v -c -m 644 "${ILIB}" "${install_folder}/${APP_LC_NAME}/bin"
@@ -620,9 +620,9 @@ do_copy_user_so() {
       if [ ! -z "${ILIB}" ]
       then
         echo "Found user 3 ${ILIB}"
-        set +e
+
+        # Add "runpath" in library with value $ORIGIN.
         patchelf --set-rpath '$ORIGIN' "${ILIB}"
-        set -e
 
         ILIB_BASE="$(basename ${ILIB})"
         /usr/bin/install -v -c -m 644 "${ILIB}" "${install_folder}/${APP_LC_NAME}/bin"

--- a/scripts/build-openocd.sh
+++ b/scripts/build-openocd.sh
@@ -702,12 +702,6 @@ then
 
 fi
 
-if [ "${target_name}" == "debian" ]
-then
-  # apt-get -y install patchelf
-  echo
-fi
-
 mkdir -p ${build_folder}
 cd ${build_folder}
 
@@ -743,9 +737,6 @@ fi
 
 if [ "${target_name}" == "debian" ]
 then
-  echo "Checking chrpath..."
-  chrpath --version
-
   echo "Checking patchelf..."
   patchelf --version
 fi
@@ -1117,7 +1108,7 @@ then
     # Be sure all these lines end in '\' to ensure lines are concatenated.
     # On some machines libftdi ends in lib64, so we refer both lib & lib64
     CPPFLAGS="-m${target_bits} -pipe" \
-    LDFLAGS='-Wl,-rpath=\$$ORIGIN -lpthread' \
+    LDFLAGS='-Wl,-lpthread' \
     \
     PKG_CONFIG_LIBDIR="${install_folder}/lib/pkgconfig":"${install_folder}/lib64/pkgconfig" \
     \
@@ -1158,12 +1149,6 @@ then
     --enable-vsllink \
     | tee "${output_folder}/configure-output.txt"
     # Note: don't forget to update the INFO.txt file after changing these.
-
-    # Note: a very important detail here is LDFLAGS='-Wl,-rpath=\$$ORIGIN which
-    # adds a special record to the ELF file asking the loader to search for the
-    # libraries first in the same folder where the executable is located. The
-    # task is complicated due to the multiple substitutions that are done on
-    # the way, and need to be escaped.
 
   elif [ "${target_name}" == "osx" ]
   then
@@ -1307,13 +1292,24 @@ then
     do_strip strip "${install_folder}/${APP_LC_NAME}/bin/openocd"
   fi
 
-  # Note: this is a very important detail, 'patchelf' changes rpath
-  # in the ELF file to $ORIGIN, asking the loader to search
-  # for the libraries first in the same folder where the executable is
-  # located.
-
-  chrpath --replace '$ORIGIN' \
-    "${install_folder}/${APP_LC_NAME}/bin/openocd"
+  # This is a very important detail: 'patchelf' sets "runpath"
+  # in the ELF file to $ORIGIN, telling the loader to search
+  # for the libraries first in LD_LIBRARY_PATH (if set) and, if not found there,
+  # to look in the same folder where the executable is located -- where
+  # this build script installs the required libraries. 
+  # Note: LD_LIBRARY_PATH can be set by a developer when testing alternate 
+  # versions of the openocd libraries without removing or overwriting 
+  # the installed library files -- not done by the typical user. 
+  # Note: patchelf changes the original "rpath" in the executable (a path 
+  # in the docker container) to "runpath" with the value "$ORIGIN". rpath 
+  # instead or runpath could be set to $ORIGIN but rpath is searched before
+  # LD_LIBRARY_PATH which requires an installed library be deleted or
+  # overwritten to test or use an alternate version. In addition, the usage of
+  # rpath is deprecated. See man ld.so for more info.  
+  # Also, runpath is added to the installed library files using patchelf, with 
+  # value $ORIGIN, in the same way. See patchelf usage in build-helper.sh.
+  #
+  patchelf --set-rpath '$ORIGIN' "${install_folder}/${APP_LC_NAME}/bin/openocd"
 
   echo
   echo "Copying shared libs..."


### PR DESCRIPTION
using patchelf() instead of chrpath() in the same way runpath is presently
set in built libraries. This eliminates the usage and dependence on the
chrpath() function and package. Also, remove error masking (set e+/-) on
calls to patchelf() for the built libraries.
    modified:   scripts/build-helper.sh
    modified:   scripts/build-openocd.sh
