### PR TITLE
build-helper: fix capitalization of variable

### DIFF
--- a/scripts/build-helper.sh
+++ b/scripts/build-helper.sh
@@ -721,9 +721,9 @@ do_container_create_distribution() {
         # ownership change is not done. 
         echo
         echo "Changing owner to non-root Linux user..."
-        chown -R ${user_id}:${group_id} ${WORK_FOLDER_PATH}/build
-        chown -R ${user_id}:${group_id} ${WORK_FOLDER_PATH}/install
-        chown -R ${user_id}:${group_id} ${WORK_FOLDER_PATH}/output
+        chown -R ${user_id}:${group_id} ${work_folder_path}/build
+        chown -R ${user_id}:${group_id} ${work_folder_path}/install
+        chown -R ${user_id}:${group_id} ${work_folder_path}/output
       fi
 }
 


### PR DESCRIPTION
Variable should not be capitalized, fix to not break build.

Fixes: https://github.com/gnu-mcu-eclipse/qemu/issues/50

I understand this is a deprecated branch, but until the linked issue is fixed, this is a quick hack? Not sure, maybe it breaks a lot of other things.